### PR TITLE
Bug fixed installing an app twice results in 2 icons on the homescreen

### DIFF
--- a/apps/homescreen/js/appmanager.js
+++ b/apps/homescreen/js/appmanager.js
@@ -35,18 +35,20 @@ var Applications = (function() {
 
   installer.oninstall = function install(event) {
     var app = event.application;
-    installedApps[app.origin] = app;
+    if (!installedApps[app.origin]) {
+      installedApps[app.origin] = app;
 
-    var icon = getIcon(app.origin);
-    if (icon) {
-      window.applicationCache.mozAdd(icon);
-    }
-
-    callbacks.forEach(function(callback) {
-      if (callback.type == 'install') {
-        callback.callback(app);
+      var icon = getIcon(app.origin);
+      if (icon) {
+        window.applicationCache.mozAdd(icon);
       }
-    });
+
+      callbacks.forEach(function(callback) {
+        if (callback.type == 'install') {
+          callback.callback(app);
+        }
+      });
+    }
   };
 
   document.documentElement.lang = 'en-US';


### PR DESCRIPTION
Bug fixed installing an app twice results in 2 icons on the homescreen

https://github.com/mozilla-b2g/gaia/issues/1763
