### PR TITLE
Bugfixing keyboard anomalies when changing from input to input

### DIFF
--- a/apps/keyboard/js/controller.js
+++ b/apps/keyboard/js/controller.js
@@ -42,6 +42,7 @@ const IMEController = (function() {
   var _currentLayout = null;
   var _currentLayoutMode = LAYOUT_MODE_DEFAULT;
   var _currentKey = null;
+  var _realInputType = null;
   var _currentInputType = null;
   var _menuLockedArea = null;
   var _lastHeight = 0;
@@ -825,10 +826,6 @@ const IMEController = (function() {
         }
 
         _reset();
-        _draw(
-          _baseLayoutName, _currentInputType,
-          _currentLayoutMode, _isUpperCase
-        );
 
         if (_requireIME()) {
           if (_getCurrentEngine().show) {
@@ -936,7 +933,7 @@ const IMEController = (function() {
           _isContinousSpacePressed = true;
 
           // Then set the keyboard uppercase for the next char
-          if (_currentInputType == 'text') {
+          if (_realInputType == 'text') {
             _isUpperCase = true;
             _draw(
               _baseLayoutName, _currentInputType,
@@ -962,7 +959,7 @@ const IMEController = (function() {
 
         if (lastKeyWasPeriod) {
           // Then set the keyboard uppercase for the next char
-          if (_currentInputType == 'text') {
+          if (_realInputType == 'text') {
             _isUpperCase = true;
             _draw(
               _baseLayoutName, _currentInputType,
@@ -1010,9 +1007,8 @@ const IMEController = (function() {
 
   // Turn to default values
   function _reset() {
-    console.log('resetting');
     _currentLayoutMode = LAYOUT_MODE_DEFAULT;
-    _isUpperCase = (_currentInputType === 'text');
+    _isUpperCase = (_realInputType === 'text');
     _isUpperCaseLocked = false;
     _lastKeyCode = 0;
 
@@ -1105,11 +1101,9 @@ const IMEController = (function() {
       delete IMERender.ime.dataset.hidden;
       IMERender.ime.classList.remove('hide');
 
+      _realInputType = type;
       _currentInputType = _mapType(type);
-      _draw(
-        _baseLayoutName, _currentInputType,
-        _currentLayoutMode, _isUpperCase
-      );
+      _reset();
 
       if (_requireIME()) {
         if (_getCurrentEngine().show) {
@@ -1120,7 +1114,6 @@ const IMEController = (function() {
       _prepareLayoutParams(_layoutParams);
       this.updateLayoutParams();
 
-      _reset();
       _notifyShowKeyboard(true);
     },
 


### PR DESCRIPTION
# Overview

Basically, reset process was wrong. Now resetting on showing IME when the proper input's type has been set. Furthermore, now reset always re-draw the UI. This is not optimal and further information is given in the next section.

Actually, two event can reset the keyboard:
1. Switching to another language
2. Showing IME when entering an input

Very issues are solved now. For instance:
- Now the shift key is properly coloured when automatically enabling uppercase.
- Now uppercase is no more _randomly_ locked.
- Now changing from one input to another after changing the layout reset both the layout and the change layout key.
# Flaws and future work

Reset should not readraw each time is called. Instead, it only should redraw when `_isUpperCase`, `_isUpperCaseLocked` or `_currentLayoutMode` actually change.
